### PR TITLE
Fix matching issue in st_starfox

### DIFF
--- a/st_starfox/source/st_starfox.cpp
+++ b/st_starfox/source/st_starfox.cpp
@@ -69,14 +69,12 @@ void stStarfox::createObj() {
     createCollision(m_fileData, 2, stageElement);
     initCameraParam();
     nw4r::g3d::ResFile posData(m_fileData->getData(Data_Type_Model, 0x64, 0xfffe));
-    if (posData.ptr() == NULL)
-    {
+    if (posData.ptr()) {
+        nw4r::g3d::ResFile copyPosData = posData;
+        createStagePositions(&copyPosData);
+    } else {
         // if no stgPos model in pac, use defaults
         createStagePositions();
-    }
-    else
-    {
-        createStagePositions(&posData);
     }
     createWind2ndOnly();
     m_wind2ndTrigger->setAreaSleep(1);


### PR DESCRIPTION
This is just a small change to make st_starfox match again. Swapping the if/else blocks and adding the superfluous copy does the trick.