### PR TITLE
Submodule update; fix st_starfox and st_otrain

### DIFF
--- a/st_otrain/Makefile
+++ b/st_otrain/Makefile
@@ -31,7 +31,7 @@ LD          := $(TOPDIR)/../tools/MWCC4_1/mwldeppc.exe
 ELF2REL     := $(TOPDIR)/../tools/elf2rel.exe
 
 
-CCFLAGS     := -Cpp_exceptions off -W illpragmas -proc gekko -nostdinc -O4,p -ipa file -inline auto -fp hard -u _prolog -u _epilog -u _unresolved -enum int -sdata 0 -sdata2 0 -func_align 4
+CCFLAGS     := -DMATCHING -Cpp_exceptions off -W illpragmas -proc gekko -nostdinc -O4,p -ipa file -inline auto -fp hard -u _prolog -u _epilog -u _unresolved -enum int -sdata 0 -sdata2 0 -func_align 4
 CXXFLAGS    := -lang=c++ $(CCFLAGS)
 LDFLAGS     := -lcf $(LCF) -r1 -fp hard -m _prolog -g -unused
 

--- a/st_otrain/source/st_onlinetrainning.cpp
+++ b/st_otrain/source/st_onlinetrainning.cpp
@@ -119,15 +119,12 @@ void stOnlineTrainning::createObj() {
     }
     createCollision(m_fileData, 2, 0);
     initCameraParam();
-    nw4r::g3d::ResFile posData(m_fileData->getData(Data_Type_Model, 0x64, 0xfffe));
-    if (posData.ptr() == NULL)
-    {
-        // if no stgPos model in pac, use defaults
-        createStagePositions();
-    }
-    else
-    {
+    void* ptr = m_fileData->getData(Data_Type_Model, 0x64, 0xfffe);
+    if (ptr) {
+        nw4r::g3d::ResFile posData(ptr);
         createStagePositions(&posData);
+    } else {
+        createStagePositions();
     }
     createWind2ndOnly();
     loadStageAttrParam(m_fileData, 0x1E);

--- a/st_starfox/Makefile
+++ b/st_starfox/Makefile
@@ -31,7 +31,7 @@ LD          := $(TOPDIR)/../tools/MWCC4_1/mwldeppc.exe
 ELF2REL     := $(TOPDIR)/../tools/elf2rel.exe
 
 
-CCFLAGS     := -Cpp_exceptions off -W illpragmas -proc gekko -nostdinc -O4,p -ipa file -inline on,noauto -fp hard -u _prolog -u _epilog -u _unresolved -enum int -sdata 0 -sdata2 0 -func_align 4
+CCFLAGS     := -DMATCHING -Cpp_exceptions off -W illpragmas -proc gekko -nostdinc -O4,p -ipa file -inline on,noauto -fp hard -u _prolog -u _epilog -u _unresolved -enum int -sdata 0 -sdata2 0 -func_align 4
 CXXFLAGS    := -lang=c++ $(CCFLAGS)
 LDFLAGS     := -lcf $(LCF) -r1 -fp hard -m _prolog -g -unused
 

--- a/st_starfox/source/st_starfox.cpp
+++ b/st_starfox/source/st_starfox.cpp
@@ -235,9 +235,9 @@ void stStarfox::updateScene(float deltaFrame) {
                     m_secondaryFileData->getData(Data_Type_Scene, m_prev_scene_num*3, 0xFFFE);
                 registScnAnim(scn, 0);
                 playSeBasic(snd_se_stage_Starfox_warp_in, 0.0f);
-                m_windAreaData2nd->m_windStrength = 0.5f;
-                m_windAreaData2nd->m_horizontalWindRotation = 361.0f;
-                m_windAreaData2nd->m_verticalWindRotation = 24.0f;
+                m_windAreaData2nd->m_speed = 0.5f;
+                m_windAreaData2nd->m_vector = 361.0f;
+                m_windAreaData2nd->m_60 = 24.0f;
                 m_windAreaData2nd->m_64 = 1.0f;
                 m_windAreaData2nd->m_72 = 0x46;
                 m_wind2ndTrigger->setWindParam(m_windAreaData2nd, 0);
@@ -384,9 +384,9 @@ void stStarfox::updateSceneEffectCorneria(float deltaFrame) {
     switch (m_corneria_phase) {
         case 1:
             if (m_curr_scene.getTimeLeft() < 1900.0f) {
-                m_windAreaData2nd->m_windStrength = 0.5f;
-                m_windAreaData2nd->m_horizontalWindRotation = 90.0f;
-                m_windAreaData2nd->m_verticalWindRotation = 16.0f;
+                m_windAreaData2nd->m_speed = 0.5f;
+                m_windAreaData2nd->m_vector = 90.0f;
+                m_windAreaData2nd->m_60 = 16.0f;
                 m_windAreaData2nd->m_64 = 0.9f;
                 m_windAreaData2nd->m_72 = 0x46;
                 m_wind2ndTrigger->setWindParam(m_windAreaData2nd, 0);
@@ -402,9 +402,9 @@ void stStarfox::updateSceneEffectCorneria(float deltaFrame) {
             break;
         case 3:
             if (m_curr_scene.getTimeLeft() < 370.0f) {
-                m_windAreaData2nd->m_windStrength = 0.6f;
-                m_windAreaData2nd->m_horizontalWindRotation = 270.0f;
-                m_windAreaData2nd->m_verticalWindRotation = 24.0f;
+                m_windAreaData2nd->m_speed = 0.6f;
+                m_windAreaData2nd->m_vector = 270.0f;
+                m_windAreaData2nd->m_60 = 24.0f;
                 m_windAreaData2nd->m_64 = 0.8f;
                 m_windAreaData2nd->m_72 = 0x3C;
                 m_wind2ndTrigger->setWindParam(m_windAreaData2nd, 0);
@@ -491,7 +491,7 @@ void stStarfox::update(float deltaFrame) {
             default:
                 break;
         }
-        Matrix nodeMtx;
+        Matrix nodeMtx(true);
         m_scene_grounds[0]->getNodeMatrix(&nodeMtx, 0, "Slope");
         nodeMtx.getRotate(&m_slope_rotate);
         float f1, f2, f3;


### PR DESCRIPTION
Fixed some build errors and matching issues in `st_otrain` and `st_starfox`. `-DMATCHING` has been added to the Makefiles for these decompilations so that custom code is not selected from BrawlHeaders.